### PR TITLE
fix networkspec update

### DIFF
--- a/cmd/networkspec/update.go
+++ b/cmd/networkspec/update.go
@@ -19,7 +19,7 @@ func UpdateCmd() *cobra.Command {
 				fmt.Println(err.Error())
 				return
 			}
-			payload := &service.NetworkSpecMetadata{}
+			payload := &service.UpdateNetworkSpecPayload{}
 			if filePath != "" {
 				err = helpers.ApplyDefinitionFile(filePath, payload)
 				if err != nil {
@@ -27,7 +27,12 @@ func UpdateCmd() *cobra.Command {
 					return
 				}
 			}
-			err = service.UpdateNetworkSpecMetadata(wsID, networkID,payload)
+			if payload.Metadata == nil {
+				err = fmt.Errorf("metadata is required but not found")
+				fmt.Println(err)
+				return
+			}
+			err = service.UpdateNetworkSpecMetadata(wsID, networkID, payload.Metadata)
 			if err != nil {
 				fmt.Println(err.Error())
 				return

--- a/pkg/service/networkspec.go
+++ b/pkg/service/networkspec.go
@@ -18,7 +18,7 @@ type BootNode struct {
 }
 
 type NetworkSpecMetadata struct {
-	Recommend 		 *Recommend    `json:"recommend,omitempty"`
+	Recommend        *Recommend    `json:"recommend,omitempty"`
 	ChainSpec        *string       `json:"chainspec,omitempty"`
 	ImageVersion     *string       `json:"imageVersion,omitempty"`
 	Command          *string       `json:"command,omitempty"`
@@ -65,6 +65,10 @@ type CreateNetworkSpecPayload struct {
 	Protocol        string              `json:"protocol"`
 	ImageRepository string              `json:"imageRepository"`
 	Metadata        NetworkSpecMetadata `json:"metadata"`
+}
+
+type UpdateNetworkSpecPayload struct {
+	Metadata *NetworkSpecMetadata `json:"metadata"`
 }
 
 type GenerateChainSpecPayload struct {


### PR DESCRIPTION
Since the subcommand is `network-spec update` not `network-spec update-metadata`, payload should have metadata as a key even it is the only thing we allow user to update for a network-spec.