### PR TITLE
To add command that lists backups enabled public networks

### DIFF
--- a/cmd/networkspec/listBackups.go
+++ b/cmd/networkspec/listBackups.go
@@ -1,0 +1,99 @@
+package networkspec
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/OnFinality-io/onf-cli/pkg/printer"
+	"github.com/OnFinality-io/onf-cli/pkg/service"
+	"github.com/spf13/cobra"
+)
+
+func listBackupsCmd() *cobra.Command {
+	printFlags := printer.NewPrintFlags()
+	c := &cobra.Command{
+		Use:   "list-backups",
+		Short: "List all the networks that supports lightning restore/backups",
+		Run: func(cmd *cobra.Command, args []string) {
+			// get public network specs data
+			specs, err := service.GetBackupNetworkSpecs()
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+
+			// get backups supported public networks data
+			backups, err2 := service.GetBackups()
+			if err2 != nil {
+				fmt.Println(err2.Error())
+				return
+			}
+			
+			// get cluster data
+			info, err3 := service.GetInfo()
+			if err3 != nil {
+				fmt.Println(err3.Error())
+				return
+			}
+
+			nsBackups := mapNetworkSpecBackups(specs, backups, info.Clusters)
+
+			printer.NewWithPrintFlag(printFlags).Print(nsBackups)
+		},
+	}
+	printFlags.AddFlags(c)
+	return c
+}
+
+func mapNetworkSpecBackups(
+	ns []service.NetworkSpecBackups,
+	nsb []service.Backups,
+	cl []service.Clusters,
+) []service.NetworkSpecBackups {
+	var (
+		nsBackups []service.NetworkSpecBackups
+		nodeTypes, cloudRegion string
+	)
+	for _, n := range ns {
+		for _, b := range nsb {
+			if n.Key == b.NetworkSpec { // filter out by networks with backups only
+				for _, c := range cl {
+					if b.ClusterHash == c.Hash && c.Active { // filter out by cluster key and active clusters
+						nodeTypes = getNodeTypeFromPruningMode(b.PruningMode, b.Protocol)
+						cloudRegion = strings.ToUpper(c.Cloud) + " - " + c.Region
+
+						nsBackups = append(nsBackups, service.NetworkSpecBackups{
+							Key: n.Key,
+							Name: n.Name,
+							DisplayName: n.DisplayName,
+							ProtocolKey: n.ProtocolKey,
+							MinStorageSize: b.StorageSize,
+							AvailNodeTypes: nodeTypes,
+							AvailCloudRegion: cloudRegion,
+							ClusterKey: c.Hash,
+						})
+					}
+				}
+			}
+		}
+	}
+	return nsBackups
+}
+
+func getNodeTypeFromPruningMode(pruningMode string, protocol string) string {
+	// TODO: find a way to get available pruning modes and protocols from APIs
+	switch strings.ToLower(pruningMode) {
+		case "archive":
+			if protocol == "polkadot-parachain" {
+				return "archive | collator"
+			} else if protocol == "substrate" {
+				return "archive | validator"
+			} else {
+				return "archive"
+			}
+		case "none":
+			return "full"
+		default:
+			return "-"
+	}
+}

--- a/cmd/networkspec/listBackups.go
+++ b/cmd/networkspec/listBackups.go
@@ -23,16 +23,16 @@ func listBackupsCmd() *cobra.Command {
 			}
 
 			// get backups supported public networks data
-			backups, err2 := service.GetBackups()
-			if err2 != nil {
-				fmt.Println(err2.Error())
+			backups, err := service.GetBackups()
+			if err != nil {
+				fmt.Println(err.Error())
 				return
 			}
 			
 			// get cluster data
-			info, err3 := service.GetInfo()
-			if err3 != nil {
-				fmt.Println(err3.Error())
+			info, err := service.GetInfo()
+			if err != nil {
+				fmt.Println(err.Error())
 				return
 			}
 
@@ -59,7 +59,7 @@ func mapNetworkSpecBackups(
 			if n.Key == b.NetworkSpec { // filter out by networks with backups only
 				for _, c := range cl {
 					if b.ClusterHash == c.Hash && c.Active { // filter out by cluster key and active clusters
-						nodeTypes = getNodeTypeFromPruningMode(b.PruningMode, b.Protocol)
+						nodeTypes = b.GetNodeTypeFromPruningMode()
 						cloudRegion = strings.ToUpper(c.Cloud) + " - " + c.Region
 
 						nsBackups = append(nsBackups, service.NetworkSpecBackups{
@@ -80,20 +80,3 @@ func mapNetworkSpecBackups(
 	return nsBackups
 }
 
-func getNodeTypeFromPruningMode(pruningMode string, protocol string) string {
-	// TODO: find a way to get available pruning modes and protocols from APIs
-	switch strings.ToLower(pruningMode) {
-		case "archive":
-			if protocol == "polkadot-parachain" {
-				return "archive | collator"
-			} else if protocol == "substrate" {
-				return "archive | validator"
-			} else {
-				return "archive"
-			}
-		case "none":
-			return "full"
-		default:
-			return "-"
-	}
-}

--- a/cmd/networkspec/listBackups.go
+++ b/cmd/networkspec/listBackups.go
@@ -52,15 +52,22 @@ func mapNetworkSpecBackups(
 ) []service.NetworkSpecBackups {
 	var (
 		nsBackups []service.NetworkSpecBackups
-		nodeTypes, cloudRegion string
+		cloudRegion, nodeTypeStr string
+		nodeTypes []string
 	)
 	for _, n := range ns {
 		for _, b := range nsb {
 			if n.Key == b.NetworkSpec { // filter out by networks with backups only
 				for _, c := range cl {
 					if b.ClusterHash == c.Hash && c.Active { // filter out by cluster key and active clusters
-						nodeTypes = b.GetNodeTypeFromPruningMode()
+						nodeTypes = b.GetNodeTypeFromPruningModeAndProtocol()
 						cloudRegion = strings.ToUpper(c.Cloud) + " - " + c.Region
+
+						if len(nodeTypes) > 0 {
+							nodeTypeStr = strings.Join(nodeTypes, " | ")
+						} else {
+							nodeTypeStr = "-"
+						}
 
 						nsBackups = append(nsBackups, service.NetworkSpecBackups{
 							Key: n.Key,
@@ -68,7 +75,7 @@ func mapNetworkSpecBackups(
 							DisplayName: n.DisplayName,
 							ProtocolKey: n.ProtocolKey,
 							MinStorageSize: b.StorageSize,
-							AvailNodeTypes: nodeTypes,
+							AvailNodeTypes: nodeTypeStr,
 							AvailCloudRegion: cloudRegion,
 							ClusterKey: c.Hash,
 						})

--- a/cmd/networkspec/networkspec.go
+++ b/cmd/networkspec/networkspec.go
@@ -16,6 +16,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		listCmd(),
+		listBackupsCmd(),
 		CreateCmd(),
 		DeleteCmd(),
 		ShowCmd(),

--- a/pkg/service/networkspec.go
+++ b/pkg/service/networkspec.go
@@ -87,6 +87,24 @@ type Backups struct {
 	PruningMode     string		`json:"pruningMode"`
 }
 
+func (b Backups) GetNodeTypeFromPruningMode() string {
+	// TODO: find a way to get available pruning modes and protocols from APIs
+	switch strings.ToLower(b.PruningMode) {
+		case "archive":
+			if b.Protocol == "polkadot-parachain" {
+				return "archive | collator"
+			} else if b.Protocol == "substrate" {
+				return "archive | validator"
+			} else {
+				return "archive"
+			}
+		case "none":
+			return "full"
+		default:
+			return "-"
+	}
+}
+
 func (c *NetworkSpec) MergeConfig(config *models.Config) {
 	if c.Config == nil {
 		c.Config = config

--- a/pkg/service/networkspec.go
+++ b/pkg/service/networkspec.go
@@ -87,21 +87,21 @@ type Backups struct {
 	PruningMode     string		`json:"pruningMode"`
 }
 
-func (b Backups) GetNodeTypeFromPruningMode() string {
+func (b Backups) GetNodeTypeFromPruningModeAndProtocol() []string {
 	// TODO: find a way to get available pruning modes and protocols from APIs
 	switch strings.ToLower(b.PruningMode) {
 		case "archive":
 			if b.Protocol == "polkadot-parachain" {
-				return "archive | collator"
+				return []string{"archive","collator"}
 			} else if b.Protocol == "substrate" {
-				return "archive | validator"
+				return []string{"archive","validator"}
 			} else {
-				return "archive"
+				return []string{"archive"}
 			}
 		case "none":
-			return "full"
+			return []string{"full"}
 		default:
-			return "-"
+			return []string{}
 	}
 }
 

--- a/pkg/service/networkspec.go
+++ b/pkg/service/networkspec.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/OnFinality-io/onf-cli/cmd/networkspec/payload"
-	"github.com/OnFinality-io/onf-cli/pkg/models"
-	"github.com/OnFinality-io/onf-cli/pkg/utils"
 	"io/ioutil"
 	"net/http/httputil"
 	"net/url"
@@ -14,6 +11,10 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/OnFinality-io/onf-cli/cmd/networkspec/payload"
+	"github.com/OnFinality-io/onf-cli/pkg/models"
+	"github.com/OnFinality-io/onf-cli/pkg/utils"
 
 	"github.com/OnFinality-io/onf-cli/pkg/api"
 )
@@ -64,6 +65,26 @@ type NetworkSpec struct {
 	Recommend       *Recommend          `json:"recommend,omitempty"`
 	NodeTypes       []SpecNodeType      `json:"nodeTypes,omitempty"`
 	Config          *models.Config      `json:"config"`
+}
+
+type NetworkSpecBackups struct {
+	Key             	string              `json:"key" header:"Network Spec Key"`
+	Name            	string              `json:"name"`
+	DisplayName     	string              `json:"displayName" header:"Name"`
+	ProtocolKey     	string              `json:"protocolKey"`
+	AvailNodeTypes  	string     			`json:"availNodeTypes" header:"Node Type"`
+	MinStorageSize  	uint   				`json:"minStorageSize" header:"Min Storage Size (Gb)"`
+	AvailCloudRegion  	string     			`json:"availCloudRegion" header:"Cloud & Region"`
+	ClusterKey 			string     			`json:"cluserKey" header:"Cluster Key"`
+}
+
+type Backups struct {
+	Id				string		`json:"id"`
+	NetworkSpec		string		`json:"networkSpec"`
+	Protocol	    string		`json:"protocol"`
+	ClusterHash		string		`json:"clusterHash"`
+	StorageSize     uint		`json:"storageSize"`
+	PruningMode     string		`json:"pruningMode"`
 }
 
 func (c *NetworkSpec) MergeConfig(config *models.Config) {
@@ -143,6 +164,19 @@ func GetNetworkSpecs(wsID uint64) ([]NetworkSpec, error) {
 	resp, d, errs := instance.Ver2().Request(api.MethodGet, path, nil).EndStruct(&specs)
 	return specs, checkError(resp, d, errs)
 }
+
+func GetBackupNetworkSpecs() ([]NetworkSpecBackups, error) {
+	var specs []NetworkSpecBackups
+	resp, d, errs := instance.Ver2().Request(api.MethodGet, "/network-specs", nil).EndStruct(&specs)
+	return specs, checkError(resp, d, errs)
+}
+
+func GetBackups() ([]Backups, error) {
+	var backups []Backups
+	resp, d, errs := instance.Ver2().Request(api.MethodGet, "/backup", nil).EndStruct(&backups)
+	return backups, checkError(resp, d, errs)
+}
+
 func CreateNetworkSpecs(wsID uint64, payload *CreateNetworkSpecPayload) (*NetworkSpec, error) {
 	argumentSections, err := GetArgumentSectionsByProtocol(payload.Protocol)
 	if err != nil {

--- a/sample/create-node.yaml
+++ b/sample/create-node.yaml
@@ -1,8 +1,8 @@
 nodeName: cli-test-validator
-nodeType: validator # full or validator
+nodeType: validator # full, archive or validator/collator
 clusterKey: sy # available values: `onf info cluster`
 networkSpecKey:  # available values: `onf network-spec list`
-initFromBackup: true # works only with polkadot and kusama for now
+initFromBackup: true # use `onf network-spec list-backups` to get correct combinations for nodeType, clusterKey & networkSpecKey values
 publicPort: true
 useApiKey: true
 storage: 40Gi


### PR DESCRIPTION
To add command that lists backups enabled public networks so that users can provide the correct combination of nodeType, clusterKey & networkSpecKey when creating a new node

New command:
`onf network-spec list-backups`

**NOTE:**
This requires the new `GET /api/v2/backup` API (from mx-api) to be deployed first before this command can be properly used.

Related JIRA ticket:
https://onfinality.atlassian.net/browse/OP-1309

Code changes:
```
modified:   cmd/networkspec/networkspec.go
- added listBackupsCmd()

modified:   pkg/service/networkspec.go
- added NetworkSpecBackups and Backups struct definitions
- added GetBackupNetworkSpecs() and GetBackups() functions
- added GetNodeTypeFromPruningMode() into service pkg as a method of Backups

modified:   sample/create-node.yaml
- modified hint comments to improve instructions on where to get the correct value combinations when using

added:       cmd/networkspec/listBackups.go
- added a new command to list all the networks that supports lightning restore/backups
```