### PR TITLE
fix the missing NodeType from GetNode api

### DIFF
--- a/pkg/service/models.go
+++ b/pkg/service/models.go
@@ -27,7 +27,7 @@ type Node struct {
 	NetworkSpecKey     string       `json:"networkSpecKey" header:"Network"`
 	WorkspaceID        uint64       `json:"workspaceId,string"`
 	OwnerID            uint64       `json:"ownerId,string"`
-	NodeType           string       `json:"nodeType"`
+	NodeType           string       `json:"type"`
 	NodeSpec           string       `json:"nodeSpec"`
 	CPU                string       `json:"cpu"`
 	Ram                string       `json:"ram"`


### PR DESCRIPTION
The type was wrongly mapped and NodeType ended with nil value.