### PR TITLE
Enable detection of target architecture

### DIFF
--- a/scripts/build/osx.sh
+++ b/scripts/build/osx.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export GOOS=darwin
-export GOARCH=amd64
+export GOARCH="$(arch)"
 
 VERSION=$(cat VERSION)
 COMMIT=$(git rev-parse HEAD)


### PR DESCRIPTION
When building on Apple Silicon, the arch flag `amd64` is no longer correct. This PR enables detection of the target environment architecture, and correctly outputs `arm64` when building on newer Apple platforms.