### PR TITLE
Remove duplicate colons in key/value mapping

### DIFF
--- a/cmd/node/show.go
+++ b/cmd/node/show.go
@@ -61,16 +61,16 @@ func show(cmd *cobra.Command, printFlags *printer.PrintFlags) {
 		return
 	}
 	informationView := []propertyView{
-		{"ID:", node.ID},
-		{"Name:", node.Name},
-		{"Workspace:", node.WorkspaceID},
-		{"Owner:", node.OwnerID},
-		{"Cluster:", node.ClusterHash},
-		{"Network:", node.NetworkSpec.DisplayName},
-		{"Image:", node.Image},
-		{"Node Size:", fmt.Sprintf("%s (CPU: %s, RAM: %s)", node.NodeSpec, node.CPU, node.Ram)},
-		{"Storage Size:", node.Storage},
-		{"Status:", node.Status},
+		{"ID", node.ID},
+		{"Name", node.Name},
+		{"Workspace", node.WorkspaceID},
+		{"Owner", node.OwnerID},
+		{"Cluster", node.ClusterHash},
+		{"Network", node.NetworkSpec.DisplayName},
+		{"Image", node.Image},
+		{"Node Size", fmt.Sprintf("%s (CPU: %s, RAM: %s)", node.NodeSpec, node.CPU, node.Ram)},
+		{"Storage Size", node.Storage},
+		{"Status", node.Status},
 	}
 	endpointsView := []propertyView{
 		{"HTTPs", node.Endpoints.RPC},


### PR DESCRIPTION
When rendering values using `--output=json`, the formatting of this specific input returns a trailing colon in the key/value mapping pairs, making it difficult to process data with downstream tools like `jq`. 

This PR removes the trailing colons, thereby making it easier to write automation using the CLI.